### PR TITLE
fixing buffer managing for the twilio node example

### DIFF
--- a/twilio/node/twilio-proxy-stereo.js
+++ b/twilio/node/twilio-proxy-stereo.js
@@ -10,7 +10,8 @@ websocketServer.on("connection", ws => {
   const deepgramLive = deepgram.transcription.live({
     encoding: "mulaw",
     sample_rate: 8000,
-    channels: 2
+    channels: 2,
+    multichannel: true
   });
 
   deepgramLive.addListener('transcriptReceived', (transcription) => {
@@ -46,8 +47,8 @@ websocketServer.on("connection", ws => {
           mixed_samples[2 * i + 1] = outbound_samples[i];
         }
 
-        inbound_samples.splice(mixable_length - inbound_samples.length);
-        outbound_samples.splice(mixable_length - outbound_samples.length);
+        inbound_samples = inbound_samples.slice(mixable_length);
+        outbound_samples = outbound_samples.slice(mixable_length);
 
         if (deepgramLive && deepgramLive.getReadyState() === 1) {
           deepgramLive.send(Buffer.from(mixed_samples));


### PR DESCRIPTION
The previous behavior gave bizarre results for, interestingly, only one of the two channels - which maybe makes sense - certainly I was using `splice` incorrectly. Empirically, this now seems to work. Will share this with Telnyx (it's working for me for stereo Telnyx out of the box).