### PR TITLE
Fix broken re-assignment of const variables

### DIFF
--- a/twilio/node/twilio-proxy-stereo.js
+++ b/twilio/node/twilio-proxy-stereo.js
@@ -16,8 +16,8 @@ websocketServer.on("connection", (ws) => {
     channels: 1,
   });
 
-  const inboundSamples = [];
-  const outboundSamples = [];
+  let inboundSamples = [];
+  let outboundSamples = [];
 
   connection.on(LiveTranscriptionEvents.Open, () => {
     connection.on(LiveTranscriptionEvents.Close, () => {


### PR DESCRIPTION
Since the sample arrays are being re-assigned to, they cannot be `const`s.