### PR TITLE
Specify the use of two channels, not one

### DIFF
--- a/twilio/node/twilio-proxy-stereo.js
+++ b/twilio/node/twilio-proxy-stereo.js
@@ -13,7 +13,7 @@ websocketServer.on("connection", (ws) => {
     smart_format: true,
     encoding: "mulaw",
     sample_rate: 8000,
-    channels: 1,
+    channels: 2,
   });
 
   const inboundSamples = [];


### PR DESCRIPTION
Telling Deepgram that there's only one channel is the audio being sent results in wildly incorrect transcriptions, and is also just incorrect since the code is interleaving two separate mono sources into a single stream.